### PR TITLE
scripts: fix clean options, clean

### DIFF
--- a/packages/scripts/src/scripts/clean.js
+++ b/packages/scripts/src/scripts/clean.js
@@ -1,9 +1,12 @@
+import { getOptions } from "../options";
 import { printInfo, printError, printDone } from "../utils/print";
 import { resolveApp } from "../utils/path";
 import fs from "fs-extra";
 
 export default async args => {
 	printInfo("Cleaning...");
+
+	const options = getOptions(null);
 
 	try {
 		await fs.remove(resolveApp(options.distDirectory));


### PR DESCRIPTION
Added the import for ```options.js``` and setup the options const to eliminate the reference error.